### PR TITLE
Fix path to bundled resource: gradle-wrapper

### DIFF
--- a/src/jsMain/kotlin/org/jetbrains/webwiz/Main.kt
+++ b/src/jsMain/kotlin/org/jetbrains/webwiz/Main.kt
@@ -37,7 +37,7 @@ fun main() {
 }
 
 private fun generateProject(project: ProjectInfo) {
-    window.fetch(window.location.origin + window.location.pathname + "/binaries/gradle-wrapper")
+    window.fetch("./binaries/gradle-wrapper")
         .then { response -> response.arrayBuffer() }
         .then { gradleWrapperBlob ->
             val zip = JSZip()


### PR DESCRIPTION
Otherwise, in the download zip we have `File not found` content inside gradle-wrapper.jar