### PR TITLE
[Issue-8] Add Kermit, SQLDelight, Ktor

### DIFF
--- a/src/commonMain/kotlin/org/jetbrains/webwiz/generator/files/ModuleBuildGradle.kt
+++ b/src/commonMain/kotlin/org/jetbrains/webwiz/generator/files/ModuleBuildGradle.kt
@@ -29,6 +29,7 @@ plugins {
     ${if (Target.ANDROID in projectInfo.targets) "id(\"com.android.library\")" else NAN}
     ${if (GradlePlugin.APPLICATION in projectInfo.gradlePlugins) "application" else NAN}
     ${if (GradlePlugin.PUBLISH in projectInfo.gradlePlugins) "`maven-publish`" else NAN}
+    ${if (GradlePlugin.SQL_DELIGHT in projectInfo.gradlePlugins) "id(\"com.squareup.sqldelight\")" else NAN}
 }
 """.trimIndent().deleteNans()
 

--- a/src/commonMain/kotlin/org/jetbrains/webwiz/generator/files/RootBuildGradle.kt
+++ b/src/commonMain/kotlin/org/jetbrains/webwiz/generator/files/RootBuildGradle.kt
@@ -3,6 +3,7 @@ package org.jetbrains.webwiz.generator.files
 import org.jetbrains.webwiz.generator.NAN
 import org.jetbrains.webwiz.generator.ProjectFile
 import org.jetbrains.webwiz.generator.deleteNans
+import org.jetbrains.webwiz.models.GradlePlugin
 import org.jetbrains.webwiz.models.KmpLibrary
 import org.jetbrains.webwiz.models.KotlinVersion
 import org.jetbrains.webwiz.models.ProjectInfo
@@ -24,6 +25,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${projectInfo.kotlinVersion.versionName}")
         ${if (projectInfo.dependencies.contains(KmpLibrary.SERIALIZATION)) "classpath(\"org.jetbrains.kotlin:kotlin-serialization:${projectInfo.kotlinVersion.versionName}\")" else NAN}
         ${if (projectInfo.targets.contains(Target.ANDROID)) "classpath(\"com.android.tools.build:gradle:7.0.2\")" else NAN}
+        ${if (GradlePlugin.SQL_DELIGHT in projectInfo.gradlePlugins) "classpath(\"com.squareup.sqldelight:gradle-plugin:1.5.3\")" else NAN}
     }
 }
 

--- a/src/commonMain/kotlin/org/jetbrains/webwiz/models/GradlePlugins.kt
+++ b/src/commonMain/kotlin/org/jetbrains/webwiz/models/GradlePlugins.kt
@@ -5,8 +5,27 @@ enum class GradlePlugin(
     val forbidden: Set<Target>,
     val userName: String
 ) {
-    PUBLISH(emptySet(), emptySet(), "Maven Publish"),
-    APPLICATION(setOf(Target.JVM), setOf(Target.ANDROID), "JVM Application");
+    PUBLISH(
+        emptySet(),
+        emptySet(),
+        "Maven Publish"
+    ),
+    APPLICATION(
+        setOf(Target.JVM),
+        setOf(Target.ANDROID),
+        "JVM Application"
+    ),
+    SQL_DELIGHT(
+        emptySet(),
+        setOf(
+            Target.ANDROID_NATIVE,
+            Target.LINUX,
+            Target.WASM,
+            Target.TV_OS,
+            Target.WATCH_OS
+        ),
+        "SQLDelight"
+    );
 
     fun canBeApplied(targets: Set<Target>): Boolean =
         targets.containsAll(mandatory) && !targets.any { it in forbidden }

--- a/src/commonMain/kotlin/org/jetbrains/webwiz/models/KmpLibraries.kt
+++ b/src/commonMain/kotlin/org/jetbrains/webwiz/models/KmpLibraries.kt
@@ -50,7 +50,22 @@ enum class KmpLibrary(
         "KotlinX DateTime",
         "org.jetbrains.kotlinx:kotlinx-datetime:0.3.1"
     ),
-    LOGGER(
+    KERMIT_LOGGER(
+        setOf(
+            Target.ANDROID,
+            Target.JVM,
+            Target.JS,
+            Target.MACOS,
+            Target.IOS,
+            Target.TV_OS,
+            Target.WATCH_OS,
+            Target.LINUX,
+            Target.WINDOWS
+        ),
+        "Kermit Logger",
+        "co.touchlab:kermit:1.0.0"
+    ),
+    NAPIER_LOGGER(
         setOf(
             Target.ANDROID,
             Target.JVM,
@@ -62,5 +77,30 @@ enum class KmpLibrary(
         ),
         "Napier logger",
         "io.github.aakira:napier:2.1.0"
-    )
+    ),
+    SQLDELIGHT_COROUTINES(
+        setOf(
+            Target.ANDROID,
+            Target.JVM,
+            Target.JS,
+            Target.IOS,
+            Target.MACOS,
+            Target.WINDOWS
+        ),
+        "SQLDelight Coroutines",
+        "com.squareup.sqldelight:coroutines-extensions:1.5.3"
+    ),
+    KTOR_CORE(
+        setOf(
+            Target.JVM,
+            Target.ANDROID,
+            Target.JS,
+            Target.IOS,
+            Target.LINUX,
+            Target.MACOS,
+            Target.WINDOWS
+        ),
+        "Ktor Core",
+        "io.ktor:ktor-client-core:1.6.7"
+    ),
 }


### PR DESCRIPTION
[Summary]
The Wizard is lacking some common libraries

[Fix]
Add the aforementioned libraries.
1. Kermit just went 1.0.0, and supports more targets than Napier.
2. SQLDelight has both a Gradle plugin and the coroutines extensions.
3. I could only add the core Ktor. Individual clients need to be
added manually (client-android, client-ios, etc.). Enabiling this will
require some further changes to support adding only to 1 source set.

[Testing]
- `./gradlew jsBrowserRun`
- `./gradlew allTests`
- manual testing

https://github.com/terrakok/kmp-web-wizard/issues/8
![Screen Shot 2021-12-11 at 5 22 27 PM](https://user-images.githubusercontent.com/22403330/145696989-54af539c-c89d-40ee-b2fa-ed45eca4863a.png)
